### PR TITLE
Clean the autoload config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,11 @@
     ],
     "autoload": {
         "psr-4": {
-            "Joli\\Jane\\": "src/",
+            "Joli\\Jane\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
             "Joli\\Jane\\Tests\\": "tests/"
         }
     },


### PR DESCRIPTION
Tests don't need to be autoloadable when installing the package as a dependency, only when running the testsuite