### PR TITLE
Fix type detection with null

### DIFF
--- a/src/Guesser/ChainGuesser.php
+++ b/src/Guesser/ChainGuesser.php
@@ -4,6 +4,7 @@ namespace Joli\Jane\Guesser;
 
 use Joli\Jane\Guesser\Guess\MultipleType;
 use Joli\Jane\Guesser\Guess\Type;
+use Joli\Jane\Guesser\JsonSchema\DateTimeGuesser;
 
 class ChainGuesser implements TypeGuesserInterface, PropertiesGuesserInterface, ClassGuesserInterface
 {
@@ -56,7 +57,14 @@ class ChainGuesser implements TypeGuesserInterface, PropertiesGuesserInterface, 
             if ($guesser->supportObject($object)) {
                 if ($type === null) {
                     $type = $guesser->guessType($object, $name, $classes);
-                    continue;
+
+                    // DateTime guesser should not end up in multiple types
+                    // TODO: there should be a more generic solution for this
+                    if ($guesser instanceof DateTimeGuesser) {
+                        break;
+                    } else {
+                        continue;
+                    }
                 }
 
                 if (!$type instanceof MultipleType) {
@@ -93,4 +101,4 @@ class ChainGuesser implements TypeGuesserInterface, PropertiesGuesserInterface, 
 
         return $properties;
     }
-} 
+}

--- a/src/Guesser/Guess/MultipleType.php
+++ b/src/Guesser/Guess/MultipleType.php
@@ -64,7 +64,33 @@ class MultipleType extends Type
     }
 
     /**
-     * (@inheritDoc}
+     * {@inheritdoc}
+     */
+    public function getTypeHint()
+    {
+        // We have exactly two types: one null and an object
+        if (count($this->types) === 2) {
+            list($type1, $type2) = $this->types;
+
+            if ($this->isOptionalObjectType($type1, $type2)) {
+                return $type2->getTypeHint();
+            }
+
+            if ($this->isOptionalObjectType($type2, $type1)) {
+                return $type1->getTypeHint();
+            }
+        }
+
+        return null;
+    }
+
+    private function isOptionalObjectType(Type $nullType, Type $objectType)
+    {
+        return 'null' === $nullType->getName() && $objectType instanceof ObjectType;
+    }
+
+    /**
+     * {@inheritdoc}
      */
     public function createDenormalizationStatement(Context $context, Expr $input)
     {
@@ -91,7 +117,7 @@ class MultipleType extends Type
         return [$statements, $output];
     }
     /**
-     * (@inheritDoc}
+     * {@inheritdoc}
      */
     public function createNormalizationStatement(Context $context, Expr $input)
     {
@@ -118,4 +144,3 @@ class MultipleType extends Type
         return [$statements, $output];
     }
 }
- 

--- a/src/Guesser/JsonSchema/SimpleTypeGuesser.php
+++ b/src/Guesser/JsonSchema/SimpleTypeGuesser.php
@@ -26,7 +26,9 @@ class SimpleTypeGuesser implements GuesserInterface, TypeGuesserInterface
     ];
 
     protected $excludeFormat = [
-        'date-time'
+        'string' => [
+            'date-time',
+        ],
     ];
 
     /**
@@ -38,7 +40,11 @@ class SimpleTypeGuesser implements GuesserInterface, TypeGuesserInterface
             &&
             in_array($object->getType(), $this->typesSupported)
             &&
-            !in_array($object->getFormat(), $this->excludeFormat)
+            (
+                !in_array($object->getType(), $this->excludeFormat)
+                ||
+                !in_array($object->getFormat(), $this->excludeFormat[$object->getType()])
+            )
         ;
     }
 

--- a/tests/fixtures/datetime/expected/Model/Test.php
+++ b/tests/fixtures/datetime/expected/Model/Test.php
@@ -8,6 +8,14 @@ class Test
      * @var \DateTime
      */
     protected $date;
+    /**
+     * @var \DateTime|null
+     */
+    protected $dateOrNull;
+    /**
+     * @var \DateTime|null|int
+     */
+    protected $dateOrNullOrInt;
 
     /**
      * @return \DateTime
@@ -25,6 +33,46 @@ class Test
     public function setDate(\DateTime $date = null)
     {
         $this->date = $date;
+
+        return $this;
+    }
+
+    /**
+     * @return \DateTime|null
+     */
+    public function getDateOrNull()
+    {
+        return $this->dateOrNull;
+    }
+
+    /**
+     * @param \DateTime|null $dateOrNull
+     *
+     * @return self
+     */
+    public function setDateOrNull(\DateTime $dateOrNull = null)
+    {
+        $this->dateOrNull = $dateOrNull;
+
+        return $this;
+    }
+
+    /**
+     * @return \DateTime|null|int
+     */
+    public function getDateOrNullOrInt()
+    {
+        return $this->dateOrNullOrInt;
+    }
+
+    /**
+     * @param \DateTime|null|int $dateOrNullOrInt
+     *
+     * @return self
+     */
+    public function setDateOrNullOrInt($dateOrNullOrInt = null)
+    {
+        $this->dateOrNullOrInt = $dateOrNullOrInt;
 
         return $this;
     }

--- a/tests/fixtures/datetime/expected/Normalizer/TestNormalizer.php
+++ b/tests/fixtures/datetime/expected/Normalizer/TestNormalizer.php
@@ -42,6 +42,29 @@ class TestNormalizer extends SerializerAwareNormalizer implements DenormalizerIn
         if (property_exists($data, 'date')) {
             $object->setDate(\DateTime::createFromFormat("Y-m-d\TH:i:sP", $data->{'date'}));
         }
+        if (property_exists($data, 'dateOrNull')) {
+            $value = $data->{'dateOrNull'};
+            if (is_object($data->{'dateOrNull'}) and false !== \DateTime::createFromFormat("Y-m-d\TH:i:sP", $data->{'dateOrNull'})) {
+                $value = \DateTime::createFromFormat("Y-m-d\TH:i:sP", $data->{'dateOrNull'});
+            }
+            if (is_null($data->{'dateOrNull'})) {
+                $value = $data->{'dateOrNull'};
+            }
+            $object->setDateOrNull($value);
+        }
+        if (property_exists($data, 'dateOrNullOrInt')) {
+            $value_1 = $data->{'dateOrNullOrInt'};
+            if (is_object($data->{'dateOrNullOrInt'}) and false !== \DateTime::createFromFormat("Y-m-d\TH:i:sP", $data->{'dateOrNullOrInt'})) {
+                $value_1 = \DateTime::createFromFormat("Y-m-d\TH:i:sP", $data->{'dateOrNullOrInt'});
+            }
+            if (is_null($data->{'dateOrNullOrInt'})) {
+                $value_1 = $data->{'dateOrNullOrInt'};
+            }
+            if (is_int($data->{'dateOrNullOrInt'})) {
+                $value_1 = $data->{'dateOrNullOrInt'};
+            }
+            $object->setDateOrNullOrInt($value_1);
+        }
 
         return $object;
     }
@@ -52,6 +75,25 @@ class TestNormalizer extends SerializerAwareNormalizer implements DenormalizerIn
         if (null !== $object->getDate()) {
             $data->{'date'} = $object->getDate()->format("Y-m-d\TH:i:sP");
         }
+        $value = $object->getDateOrNull();
+        if (is_object($object->getDateOrNull())) {
+            $value = $object->getDateOrNull()->format("Y-m-d\TH:i:sP");
+        }
+        if (is_null($object->getDateOrNull())) {
+            $value = $object->getDateOrNull();
+        }
+        $data->{'dateOrNull'} = $value;
+        $value_1              = $object->getDateOrNullOrInt();
+        if (is_object($object->getDateOrNullOrInt())) {
+            $value_1 = $object->getDateOrNullOrInt()->format("Y-m-d\TH:i:sP");
+        }
+        if (is_null($object->getDateOrNullOrInt())) {
+            $value_1 = $object->getDateOrNullOrInt();
+        }
+        if (is_int($object->getDateOrNullOrInt())) {
+            $value_1 = $object->getDateOrNullOrInt();
+        }
+        $data->{'dateOrNullOrInt'} = $value_1;
 
         return $data;
     }

--- a/tests/fixtures/datetime/schema.json
+++ b/tests/fixtures/datetime/schema.json
@@ -7,6 +7,14 @@
         "date": {
             "type": "string",
             "format": "date-time"
+        },
+        "dateOrNull": {
+            "type": ["string", "null"],
+            "format": "date-time"
+        },
+        "dateOrNullOrInt": {
+            "type": ["string", "null", "integer"],
+            "format": "date-time"
         }
     }
 }


### PR DESCRIPTION
This tries to address #26 

The PR contains:

- Fixes simple type detection when format is applied to multiple types
- Breaks the guesser chain when a DateTime guesser guesses a type (should be expanded to a more general solution, possibly object guessers should break the chain)
- If a MultipleType is a nullable object type, then typehint is correctly set to the object with the optional null value as usual.