### PR TITLE
Date time is in string format in the normalized data

### DIFF
--- a/src/Guesser/Guess/DateTimeType.php
+++ b/src/Guesser/Guess/DateTimeType.php
@@ -54,17 +54,12 @@ class DateTimeType extends ObjectType
      */
     public function createConditionStatement(Expr $input)
     {
-        return new Expr\BinaryOp\LogicalAnd(new Expr\FuncCall(
-            new Name($this->normalizationConditionMapping[$this->name]), [
+        return new Expr\BinaryOp\NotIdentical(
+            new Expr\ConstFetch(new Name('false')),
+            new Expr\StaticCall(new Name('\DateTime'), 'createFromFormat', [
+                new Arg(new Expr\ConstFetch(new Name('"'.$this->format.'"'))),
                 new Arg($input),
-            ]),
-            new Expr\BinaryOp\NotIdentical(
-                new Expr\ConstFetch(new Name('false')),
-                new Expr\StaticCall(new Name('\DateTime'), 'createFromFormat', [
-                    new Arg(new Expr\ConstFetch(new Name('"'.$this->format.'"'))),
-                    new Arg($input),
-                ])
-            )
+            ])
         );
     }
 }

--- a/src/Guesser/Guess/DateTimeType.php
+++ b/src/Guesser/Guess/DateTimeType.php
@@ -54,12 +54,17 @@ class DateTimeType extends ObjectType
      */
     public function createConditionStatement(Expr $input)
     {
-        return new Expr\BinaryOp\NotIdentical(
-            new Expr\ConstFetch(new Name('false')),
-            new Expr\StaticCall(new Name('\DateTime'), 'createFromFormat', [
-                new Arg(new Expr\ConstFetch(new Name('"'.$this->format.'"'))),
+        return new Expr\BinaryOp\LogicalAnd(new Expr\FuncCall(
+            new Name('is_string'), [
                 new Arg($input),
-            ])
+            ]),
+            new Expr\BinaryOp\NotIdentical(
+                new Expr\ConstFetch(new Name('false')),
+                new Expr\StaticCall(new Name('\DateTime'), 'createFromFormat', [
+                    new Arg(new Expr\ConstFetch(new Name('"'.$this->format.'"'))),
+                    new Arg($input),
+                ])
+            )
         );
     }
 }


### PR DESCRIPTION
This will make a difference once #26 and #29 gets fixed: In the normalized data DateTime is not an object, but string, thus object check does not make sense there.